### PR TITLE
Just a QOL improvement for keyboard

### DIFF
--- a/UdonKeyboard/KeyboardManager.cs
+++ b/UdonKeyboard/KeyboardManager.cs
@@ -26,6 +26,7 @@ public class KeyboardManager : UdonSharpBehaviour
     private bool caps;
     private bool shift;
     private bool visible;
+    private Vector3 pos;
 
     public void Start()
     {
@@ -37,7 +38,7 @@ public class KeyboardManager : UdonSharpBehaviour
         VRCPlayerApi player = Networking.LocalPlayer;
         if (player != null)
         {
-            Vector3 pos = player.GetPosition();
+            pos = player.GetPosition();
             pos.y = player.GetTrackingData(VRCPlayerApi.TrackingDataType.Head).position.y - 1.7F;
             gameObject.transform.position = pos;
 

--- a/UdonKeyboard/KeyboardManager.cs
+++ b/UdonKeyboard/KeyboardManager.cs
@@ -37,7 +37,9 @@ public class KeyboardManager : UdonSharpBehaviour
         VRCPlayerApi player = Networking.LocalPlayer;
         if (player != null)
         {
-            gameObject.transform.position = player.GetPosition();
+            Vector3 pos = player.GetPosition();
+            pos.y = player.GetTrackingData(VRCPlayerApi.TrackingDataType.Head).position.y - 1.7F;
+            gameObject.transform.position = pos;
 
             // If the keyboard is active, the log screen should sit above the keyboard.
             if (gameObject.activeSelf)


### PR DESCRIPTION
It makes the keyboard dynamically adjust its y height depending on how tall the avatar is.

Even though I did this change purely on github when I made this commit, I did test it quite a bit using bone positioning, but there's a major issue I found with bones.

Bones != accurate positioning, some avatars have bones far larger than the avatar, some smaller, and others just right. TrackingData follows how vrchat adjusts to the player's positioning.

Bones are inaccurate, and due to that I want a partnership to work on this for your VR button system, as I am a pure desktop user, it is inconvenient for me.
